### PR TITLE
Add support for x64 - Intel based Mac(s)

### DIFF
--- a/LlamaBarn.xcodeproj/project.pbxproj
+++ b/LlamaBarn.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 		156891A92E2685F900F71BD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -351,6 +351,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 0.0.0;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = app.llamabarn.LlamaBarn.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -362,7 +363,7 @@
 		156891AA2E2685F900F71BD4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "";

--- a/llama-cpp/combine.py
+++ b/llama-cpp/combine.py
@@ -1,0 +1,33 @@
+import os
+
+required_files = [
+    "libggml.dylib",
+    "libggml-base.dylib",
+    "libggml-blas.dylib",
+    "libggml-cpu.dylib",
+    "libggml-rpc.dylib",
+    "libggml-metal.dylib",
+    "libllama.dylib",
+    "libmtmd.dylib",
+    "llama-server"
+]
+
+arm64_llamacpp_dir = input("Enter the path to the arm64 llamacpp bin directory: ")
+x86_llamacpp_dir = input("Enter the path to the x86 llamacpp bin directory: ")
+output_dir = input("Enter the output directory for the combined files: ")
+
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+    
+# Using lipo to create a universal binary/dylib
+for file in required_files:
+    arm64_file_path = os.path.join(arm64_llamacpp_dir, file)
+    x86_file_path = os.path.join(x86_llamacpp_dir, file)
+    output_file_path = os.path.join(output_dir, file)
+    
+    if os.path.exists(arm64_file_path) and os.path.exists(x86_file_path):
+        lipo_command = f"lipo -create '{arm64_file_path}' '{x86_file_path}' -output '{output_file_path}'"
+        os.system(lipo_command)
+        print(f"Created universal binary: {output_file_path}")
+    else:
+        print(f"Missing file for lipo: {file}")


### PR DESCRIPTION
Related to #6

- [x] Modify Xcode project build setting to produce universal binary for LlamaBarn
- [x] Include script to combine x64 and arm64 dylibs and executables into universal dylibs/executables