### PR TITLE
support a18 in metalConfig

### DIFF
--- a/LlamaBarn/System/LlamaInstaller.swift
+++ b/LlamaBarn/System/LlamaInstaller.swift
@@ -82,9 +82,9 @@ enum LlamaInstaller {
 
   // MARK: - Steps
 
-  /// Maps this Mac's CPU to a Metal bucket config (`m1`…`m5`), mirroring
+  /// Maps this Mac's CPU to a Metal bucket config (`m1`…`m5`, `a18`), mirroring
   /// `install.sh`, which buckets every M-series variant (Pro/Max/Ultra) by
-  /// generation number.
+  /// generation number and also accepts the A18 (non-M MacBook).
   private static func metalConfig() throws -> String {
     var size = 0
     sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
@@ -93,12 +93,11 @@ enum LlamaInstaller {
     sysctlbyname("machdep.cpu.brand_string", &buf, &size, nil, 0)
     let brand = String(cString: buf)
 
-    guard let range = brand.range(of: "Apple M[1-5]", options: .regularExpression),
-      let digit = brand[range].last
+    guard let range = brand.range(of: "Apple (M[1-5]|A18)", options: .regularExpression)
     else {
       throw InstallError.unsupportedHardware(brand)
     }
-    return "m\(digit)"
+    return brand[range].dropFirst("Apple ".count).lowercased()
   }
 
   /// Ensures the `unzstd` helper is present, fetching it once and caching it


### PR DESCRIPTION
metalConfig() only matched Apple M[1-5] so the managed install failed on the A18 MacBook with unsupportedHardware

upstream install.sh already accepts M[12345]|A18 and the bucket serves aarch64/macos/metal/a18/llama-app.zst for the pinned b9553, so this just mirrors that: match Apple (M[1-5]|A18) and return the lowercased chip token

disclaimer: my julien-cto agent helped me write this