### PR TITLE
Auto-configure MTP drafter sidecar for speculative decoding

### DIFF
--- a/Llama/Models/Model.swift
+++ b/Llama/Models/Model.swift
@@ -18,7 +18,7 @@ struct Model: Identifiable {
   /// Maximum context length in tokens. 128k upper bound — clamped by the
   /// memory budget once `ctxBytesPer1kTokens` is measured.
   let ctxWindow: Int
-  /// Total bytes on disk for the model (main + shards + mmproj).
+  /// Total bytes on disk for the model (main + shards + mmproj + mtp sidecars).
   let fileSize: Int64
   /// Estimated KV-cache footprint for a 1k-token context, in bytes.
   /// 0 = MemProfile probe is pending; -1 = probe failed; >0 = measured.

--- a/Llama/Models/ModelManager.swift
+++ b/Llama/Models/ModelManager.swift
@@ -388,6 +388,15 @@ class ModelManager: NSObject, URLSessionDataDelegate {
         content += "mmproj = \(mmprojPath)\n"
       }
 
+      // A `mtp*.gguf` sidecar is a multi-token-prediction drafter — wire it up
+      // for speculative decoding so the model runs with its drafter (the server
+      // is launched with `--spec-default`). `spec-draft-n-max` is left at the
+      // binary's default. Keys map to the matching `--spec-*` server flags.
+      if let mtpPath = paths.mtpFile {
+        content += "spec-draft-model = \(mtpPath)\n"
+        content += "spec-type = draft-mtp\n"
+      }
+
       if useLargeBatch {
         content += "ubatch-size = 2048\n"
       }

--- a/Llama/Models/ResolvedPaths.swift
+++ b/Llama/Models/ResolvedPaths.swift
@@ -9,6 +9,9 @@ struct ResolvedPaths {
   let additionalParts: [String]
   /// Absolute path to the mmproj file (vision models), nil if not applicable
   let mmprojFile: String?
+  /// Absolute path to the MTP / speculative-decoding draft sidecar
+  /// (`mtp*.gguf`), nil if not applicable
+  let mtpFile: String?
   /// HF cache repo directory name (e.g. "models--bartowski--Llama-3.2-1B-Instruct-GGUF").
   /// Used by deletion to clean up the per-repo directory tree.
   let hfRepoDirName: String
@@ -17,11 +20,13 @@ struct ResolvedPaths {
     modelFile: String,
     additionalParts: [String],
     mmprojFile: String?,
+    mtpFile: String? = nil,
     hfRepoDirName: String
   ) {
     self.modelFile = modelFile
     self.additionalParts = additionalParts
     self.mmprojFile = mmprojFile
+    self.mtpFile = mtpFile
     self.hfRepoDirName = hfRepoDirName
   }
 
@@ -31,6 +36,9 @@ struct ResolvedPaths {
     paths.append(contentsOf: additionalParts)
     if let mmproj = mmprojFile {
       paths.append(mmproj)
+    }
+    if let mtp = mtpFile {
+      paths.append(mtp)
     }
     return paths
   }

--- a/Llama/System/HFCache.swift
+++ b/Llama/System/HFCache.swift
@@ -504,7 +504,9 @@ enum HFCache {
 
     return allFiles.filter { relativePath in
       let fileName = URL(fileURLWithPath: relativePath).lastPathComponent.lowercased()
-      return fileName.hasSuffix(".gguf") && !fileName.hasPrefix("mmproj")
+      return fileName.hasSuffix(".gguf")
+        && !fileName.hasPrefix("mmproj")
+        && !fileName.hasPrefix("mtp")
     }
   }
 
@@ -527,6 +529,29 @@ enum HFCache {
     // A lone sidecar is unambiguous; skip when multiple candidates exist.
     guard candidates.count == 1, let mmproj = candidates.first else { return nil }
     return modelDir.appendingPathComponent(mmproj).path
+  }
+
+  /// Finds the MTP / speculative-decoding draft sidecar (`mtp*.gguf`) living
+  /// alongside the model file. Like mmproj, `collectGgufFiles` filters these out
+  /// of the runnable-model set, so the scan would otherwise lose them and the
+  /// model would run without its drafter. When present, `models.ini` gets the
+  /// `spec-draft-model`/`spec-type` lines that enable multi-token prediction.
+  /// Returns the absolute path of a lone sidecar in the model's directory, or
+  /// nil if there are none/ambiguous.
+  private static func findMtpFile(modelFilePath: String, fm: FileManager) -> String? {
+    let modelDir = URL(fileURLWithPath: modelFilePath).deletingLastPathComponent()
+    guard let files = try? fm.contentsOfDirectory(atPath: modelDir.path) else {
+      return nil
+    }
+
+    let candidates = files.filter {
+      let name = $0.lowercased()
+      return name.hasPrefix("mtp") && name.hasSuffix(".gguf")
+    }
+
+    // A lone sidecar is unambiguous; skip when multiple candidates exist.
+    guard candidates.count == 1, let mtp = candidates.first else { return nil }
+    return modelDir.appendingPathComponent(mtp).path
   }
 
   /// Builds a `Model` + `ResolvedPaths` from a discovered GGUF file.
@@ -567,14 +592,15 @@ enum HFCache {
       filePaths = [snapshotDir.appendingPathComponent(filename).path]
     }
 
-    // Vision projection sidecar (if any) sits alongside the main file.
+    // Vision projection + MTP draft sidecars (if any) sit alongside the main file.
     let mmprojFile = findMmprojFile(modelFilePath: filePaths[0], fm: fm)
+    let mtpFile = findMtpFile(modelFilePath: filePaths[0], fm: fm)
 
     // Resolve symlinks before reading attributes — HF cache stores symlinks in
     // snapshot dirs pointing to blobs, and attributesOfItem returns the symlink
     // size (not the target file size) for symlinks. Size aggregates main +
-    // shards + mmproj to match `Model.fileSize`.
-    let sizedPaths = filePaths + (mmprojFile.map { [$0] } ?? [])
+    // shards + mmproj + mtp to match `Model.fileSize`.
+    let sizedPaths = filePaths + (mmprojFile.map { [$0] } ?? []) + (mtpFile.map { [$0] } ?? [])
     let totalFileSize: Int64 = sizedPaths.reduce(0) { sum, path in
       let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
       return sum + fm.fileSize(atPath: resolved)
@@ -618,6 +644,7 @@ enum HFCache {
       modelFile: mainFilePath,
       additionalParts: additionalParts,
       mmprojFile: mmprojFile,
+      mtpFile: mtpFile,
       hfRepoDirName: repoDir
     )
 

--- a/Llama/System/HFCache.swift
+++ b/Llama/System/HFCache.swift
@@ -508,6 +508,27 @@ enum HFCache {
     }
   }
 
+  /// Finds the vision projection sidecar (`mmproj*.gguf`) living alongside the
+  /// model file. `collectGgufFiles` filters these out of the runnable-model set,
+  /// so the scan would otherwise lose them and `models.ini` would omit the
+  /// `mmproj =` line vision models need. Returns the absolute path of a lone
+  /// sidecar in the model's directory, or nil if there are none/ambiguous.
+  private static func findMmprojFile(modelFilePath: String, fm: FileManager) -> String? {
+    let modelDir = URL(fileURLWithPath: modelFilePath).deletingLastPathComponent()
+    guard let files = try? fm.contentsOfDirectory(atPath: modelDir.path) else {
+      return nil
+    }
+
+    let candidates = files.filter {
+      let name = $0.lowercased()
+      return name.hasPrefix("mmproj") && name.hasSuffix(".gguf")
+    }
+
+    // A lone sidecar is unambiguous; skip when multiple candidates exist.
+    guard candidates.count == 1, let mmproj = candidates.first else { return nil }
+    return modelDir.appendingPathComponent(mmproj).path
+  }
+
   /// Builds a `Model` + `ResolvedPaths` from a discovered GGUF file.
   ///
   /// Quant derivation uses `GGUFQuantLabel.parse` first and falls back to
@@ -546,10 +567,15 @@ enum HFCache {
       filePaths = [snapshotDir.appendingPathComponent(filename).path]
     }
 
+    // Vision projection sidecar (if any) sits alongside the main file.
+    let mmprojFile = findMmprojFile(modelFilePath: filePaths[0], fm: fm)
+
     // Resolve symlinks before reading attributes — HF cache stores symlinks in
     // snapshot dirs pointing to blobs, and attributesOfItem returns the symlink
-    // size (not the target file size) for symlinks.
-    let totalFileSize: Int64 = filePaths.reduce(0) { sum, path in
+    // size (not the target file size) for symlinks. Size aggregates main +
+    // shards + mmproj to match `Model.fileSize`.
+    let sizedPaths = filePaths + (mmprojFile.map { [$0] } ?? [])
+    let totalFileSize: Int64 = sizedPaths.reduce(0) { sum, path in
       let resolved = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
       return sum + fm.fileSize(atPath: resolved)
     }
@@ -591,7 +617,7 @@ enum HFCache {
     let paths = ResolvedPaths(
       modelFile: mainFilePath,
       additionalParts: additionalParts,
-      mmprojFile: nil,
+      mmprojFile: mmprojFile,
       hfRepoDirName: repoDir
     )
 


### PR DESCRIPTION
Fixes #97 (the auto-configuration half — see Scope below).

## Problem

A model that ships a multi-token-prediction (MTP) drafter alongside it — an `mtp*.gguf` sidecar in its HF cache dir, e.g. unsloth's gemma-4 `mtp-gemma-4-12B-it.gguf` — runs **without speculative decoding**. The cache scan never carried the drafter, so `models.ini` omitted the spec config and `llama-server` loaded only the main model, even though the app already launches with `--spec-default`.

Concretely, from the issue, what runs is just:
```
llama serve … --model …/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf
```
with no `--spec-draft-model` / `--spec-type`, despite the `mtp-*.gguf` sidecar sitting right next to it in the snapshot dir.

## Fix

Mirror the existing mmproj sidecar handling:

- **Detect** the lone `mtp*.gguf` sidecar in the model's directory (skip when ambiguous, matching `findMmprojFile` / `HFRepoResolver.pickMmproj`).
- **Thread** it through `ResolvedPaths.mtpFile`.
- **Emit** into `models.ini`:
  ```
  spec-draft-model = /…/mtp-gemma-4-12B-it.gguf
  spec-type = draft-mtp
  ```
  These keys map to the matching `--spec-draft-model` / `--spec-type draft-mtp` server flags (verified against `llama serve --help`). `spec-draft-n-max` is left at the binary's default (3).
- **Exclude** `mtp*.gguf` from the runnable-model set in `collectGgufFiles` (so the drafter isn't listed as its own model), and fold its size into the aggregate to keep `Model.fileSize` accurate.

## Scope

This covers the **auto-configuration** part of #97 — models already present in the HF cache. Two follow-ups from the issue are intentionally **out of scope** here:
- Attaching the MTP sidecar on the *download* path (`HFRepoResolver`), so deeplink/catalog installs also fetch it.
- *Offering* MTP-capable repos in the catalog (a curation/product decision).

## Note

Stacked on #101 (the mmproj cache-scan fix) — both touch `HFCache.buildSideloadedEntry`'s sidecar detection. Until #101 merges this PR shows both commits; once it does, only the MTP commit remains. Happy to rebase if you'd prefer it land independently.

## Testing

Builds clean (`xcodebuild -scheme Llama`). I don't have an MTP model locally to exercise end-to-end; the `models.ini` keys were validated against `llama serve --help` on the installed b9700 binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)