### PR TITLE
Let users supply additional CLI arguments to llama-server

### DIFF
--- a/Llama/Settings/SettingsWindow.swift
+++ b/Llama/Settings/SettingsWindow.swift
@@ -116,6 +116,8 @@ struct SettingsView: View {
   // Effective server port; re-read after the edit sheet saves so the row updates.
   @State private var serverPort = LlamaServer.port
   @State private var showingServerPortSheet = false
+  @State private var customServerArgs = UserSettings.customServerArguments ?? ""
+  @State private var showingServerArgsSheet = false
 
   var body: some View {
     Form {
@@ -180,6 +182,44 @@ struct SettingsView: View {
           // nil resets to the default; the setter restarts the server once.
           UserSettings.serverPort = newPort
           serverPort = LlamaServer.port
+        }
+      }
+
+      // Additional server arguments section
+      Section {
+        SettingRow(
+          title: "Additional arguments",
+          description: "Extra flags appended to the server command."
+        ) {
+          HStack(spacing: 6) {
+            // Only offer a reset when custom arguments are set.
+            if UserSettings.hasCustomServerArguments {
+              RestoreDefaultButton {
+                UserSettings.customServerArguments = nil
+                customServerArgs = UserSettings.customServerArguments ?? ""
+              }
+            }
+
+            Button {
+              showingServerArgsSheet = true
+            } label: {
+              if customServerArgs.isEmpty {
+                Text("Set")
+              } else {
+                Text(customServerArgs)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+              }
+            }
+            .controlSize(.small)
+          }
+          .font(.callout)
+        }
+      }
+      .sheet(isPresented: $showingServerArgsSheet) {
+        CustomServerArgumentsSheet(currentValue: customServerArgs) { newValue in
+          UserSettings.customServerArguments = newValue.isEmpty ? nil : newValue
+          customServerArgs = UserSettings.customServerArguments ?? ""
         }
       }
 
@@ -302,7 +342,7 @@ struct SettingsView: View {
   /// changes -- the actual spec is sourced from `LlamaServer` so it stays in
   /// lockstep with what `start()` runs.
   private var serverCommand: String {
-    _ = (serverPort, sleepIdleTime, hfCacheDir)  // establish SwiftUI dependencies
+    _ = (serverPort, sleepIdleTime, hfCacheDir, customServerArgs)  // establish SwiftUI dependencies
     return LlamaServer.buildLaunchSpec()?.displayCommand ?? "llama not installed"
   }
 
@@ -540,6 +580,66 @@ struct HFTokenSheet: View {
     .frame(width: 400)
     .onAppear {
       tokenText = currentToken
+    }
+  }
+}
+
+/// Sheet for editing additional server arguments.
+struct CustomServerArgumentsSheet: View {
+  let currentValue: String
+  let onSave: (String) -> Void
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var argsText: String = ""
+
+  private var trimmed: String {
+    argsText.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Additional arguments")
+          .font(.headline)
+
+        Text(
+          "Passed verbatim to llama serve, after the built-in flags. Example: --threads 8 --temp 0.7"
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      }
+
+      TextEditor(text: $argsText)
+        .font(.system(size: 11, design: .monospaced))
+        .frame(height: 50)
+        .scrollContentBackground(.hidden)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+
+      HStack {
+        Spacer()
+
+        Button("Cancel") {
+          dismiss()
+        }
+        .keyboardShortcut(.cancelAction)
+
+        Button("Save") {
+          onSave(trimmed)
+          dismiss()
+        }
+        .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(20)
+    .frame(width: 400)
+    .onAppear {
+      argsText = currentValue
     }
   }
 }

--- a/Llama/Settings/UserSettings.swift
+++ b/Llama/Settings/UserSettings.swift
@@ -32,6 +32,7 @@ enum UserSettings {
     static let hasSetDefaultLaunchAtLogin = "hasSetDefaultLaunchAtLogin"
     static let exposeToNetwork = "exposeToNetwork"
     static let serverPort = "serverPort"
+    static let customServerArgs = "customServerArgs"
     static let sleepIdleTime = "sleepIdleTime"
     static let selectedCtxTiers = "selectedCtxTiers"
     static let hfCacheDirectory = "hfCacheDirectory"
@@ -107,6 +108,117 @@ enum UserSettings {
       }
       NotificationCenter.default.post(name: .LBUserSettingsDidChange, object: nil)
     }
+  }
+
+  /// Additional arguments appended to `llama serve`, or `nil` for none.
+  /// Whitespace-only stored values read as unset.
+  static var customServerArguments: String? {
+    get {
+      guard let value = defaults.string(forKey: Keys.customServerArgs) else { return nil }
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+    set {
+      // Normalize: keep only a non-empty string, otherwise fall back to no extra flags.
+      var normalized = newValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+      if normalized?.isEmpty == true { normalized = nil }
+      // Avoid a redundant change notification (which would needlessly restart
+      // the server) when the effective value isn't actually changing.
+      guard normalized != customServerArguments else { return }
+      if let normalized {
+        defaults.set(normalized, forKey: Keys.customServerArgs)
+      } else {
+        defaults.removeObject(forKey: Keys.customServerArgs)
+      }
+      NotificationCenter.default.post(name: .LBUserSettingsDidChange, object: nil)
+    }
+  }
+
+  /// Whether additional server arguments are configured
+  static var hasCustomServerArguments: Bool {
+    customServerArguments != nil
+  }
+
+  /// Flags the app owns because health checks and UI URLs read
+  /// `LlamaServer.port` / `resolvedHost`.
+  private static let appOwnedServerArgumentFlags: Set<String> = ["--port", "--host"]
+
+  /// Tokenizes the user-entered server arguments into argv elements. Quotes are
+  /// stripped while keeping values with spaces together, so advanced flags can
+  /// be passed through without exposing a full shell parser.
+  static var customServerArgumentTokens: [String] {
+    guard let arguments = customServerArguments else { return [] }
+    return filterAppOwnedServerArguments(tokenizeServerArguments(arguments))
+  }
+
+  private static func tokenizeServerArguments(_ input: String) -> [String] {
+    var tokens: [String] = []
+    var current = ""
+    var activeQuote: Character?
+    var hasToken = false
+
+    for char in input {
+      if let quote = activeQuote {
+        if char == quote {
+          activeQuote = nil
+        } else {
+          current.append(char)
+        }
+        hasToken = true
+        continue
+      }
+
+      if char == "\"" || char == "'" {
+        activeQuote = char
+        hasToken = true
+      } else if char.isWhitespace {
+        if hasToken {
+          tokens.append(current)
+          current.removeAll()
+          hasToken = false
+        }
+      } else {
+        current.append(char)
+        hasToken = true
+      }
+    }
+
+    if hasToken {
+      tokens.append(current)
+    }
+
+    return tokens
+  }
+
+  private static func filterAppOwnedServerArguments(_ tokens: [String]) -> [String] {
+    var filtered: [String] = []
+    var index = tokens.startIndex
+
+    while index < tokens.endIndex {
+      let token = tokens[index]
+
+      if appOwnedServerArgumentFlags.contains(token) {
+        let next = tokens.index(after: index)
+        if next < tokens.endIndex, !tokens[next].hasPrefix("-") {
+          index = tokens.index(after: next)
+        } else {
+          index = next
+        }
+        continue
+      }
+
+      if let equalsIndex = token.firstIndex(of: "="),
+        appOwnedServerArgumentFlags.contains(String(token[..<equalsIndex]))
+      {
+        index = tokens.index(after: index)
+        continue
+      }
+
+      filtered.append(token)
+      index = tokens.index(after: index)
+    }
+
+    return filtered
   }
 
   /// How long to wait before unloading the model from memory when idle.

--- a/Llama/System/LlamaServer.swift
+++ b/Llama/System/LlamaServer.swift
@@ -305,6 +305,10 @@ class LlamaServer {
       ])
     }
 
+    // User-supplied extra flags come last so they can override the built-ins
+    // above, and so the rendered "Server command" preview shows them too.
+    arguments.append(contentsOf: UserSettings.customServerArgumentTokens)
+
     return LaunchSpec(executablePath: llamaPath, arguments: arguments, env: env)
   }
 


### PR DESCRIPTION
## Summary

Adds an "Additional arguments" setting that lets you pass extra `llama serve` flags the GUI doesn't expose. The value is a single string the app tokenizes into argv and appends to the server launch spec after the built-in flags.

## Why this matters

As raised in #71, the GUI only surfaces a handful of server options (port, idle timeout, model directory), but `llama serve` accepts many more (sampling, threading, and experimental llama.cpp flags). The environment-variable route doesn't help here: a macOS GUI app launched from Finder doesn't inherit the shell environment, so `LLAMA_ARG_*` never reaches the server. A persisted setting is the only way to get these flags through, which is the direction the issue discussion landed on.

## How it works

`UserSettings.customServerArguments` (Llama/Settings/UserSettings.swift) is a persisted `String?` that follows the existing `serverPort` setter exactly: it trims the value, treats empty or whitespace-only as unset, skips a redundant write, and posts `.LBUserSettingsDidChange` so the `LlamaServer` observer reloads the server once when the value changes. `LlamaServer.buildLaunchSpec()` appends the tokenized result last, so the flags also appear in the read-only "Server command" preview for free and an unset value leaves the spec identical to before.

Tokenizing happens with a small scanner rather than a naive split so that simple single/double quoting works (a quoted path with spaces stays one argv element) and runs of whitespace never produce empty tokens. `--port` and `--host` are dropped from the user tokens on purpose: the rest of the app derives its health-check target and the menu/WebUI URLs from `LlamaServer.port` and `resolvedHost`, so a custom `--port` would bind the server somewhere the app isn't polling and leave it stuck loading. Every other flag passes through untouched.

The Settings row sits next to "Server port" and reuses the existing `ServerPortSheet` / `RestoreDefaultButton` pattern: a button opens an edit sheet with Save/Cancel, and a restore-default button appears only once a custom value is set.

## Testing

Verified that `--threads 8 --temp 0.7` appears as the trailing tokens of `buildLaunchSpec().arguments` and in the rendered command with a single reload on save; that a quoted path with spaces stays one element; that clearing the field reproduces the no-custom-args launch spec exactly; and that leading, trailing, and repeated internal whitespace collapse without empty tokens.

Fixes #71
