### PR TITLE
fix(app): store debug menu observer on AppDelegate to fix compiler warning

### DIFF
--- a/Llama/LlamaApp.swift
+++ b/Llama/LlamaApp.swift
@@ -33,6 +33,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   private var updatesObserver: NSObjectProtocol?
   private var recheckCLIObserver: NSObjectProtocol?
   private var globalInputObserver: NSObjectProtocol?
+  #if DEBUG
+    private var debugMenuObserver: NSObjectProtocol?
+  #endif
 
   // Deeplink (llama://) plumbing.
   // Cold-launch URL events arrive before `applicationDidFinishLaunching`, so we have
@@ -197,11 +200,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       if !ModelManager.shared.downloadedModels.isEmpty {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: openMenu)
       } else {
-        var token: NSObjectProtocol?
-        token = NotificationCenter.default.addObserver(
+        debugMenuObserver = NotificationCenter.default.addObserver(
           forName: .LBModelDownloadedListDidChange, object: nil, queue: .main
-        ) { _ in
-          if let token { NotificationCenter.default.removeObserver(token) }
+        ) { [weak self] _ in
+          if let observer = self?.debugMenuObserver {
+            NotificationCenter.default.removeObserver(observer)
+            self?.debugMenuObserver = nil
+          }
           openMenu()
         }
       }


### PR DESCRIPTION
### Summary
While setting up and building the project, I noticed a compiler warning in `LlamaApp.swift` (line 201) regarding mutable variable capture (`var token`) inside an escaping `NotificationCenter` closure.

This PR stores the debug menu observer on `AppDelegate` (`debugMenuObserver`), matching the exact `NotificationCenter.default.addObserver` pattern used throughout `LlamaApp.swift`.

### Changes
- Added `#if DEBUG private var debugMenuObserver: NSObjectProtocol? #endif` to `AppDelegate`.
- Updated the one-shot observer in `applicationDidFinishLaunching` to use `self?.debugMenuObserver` and unregister itself cleanly.

Tested build locally on Xcode and compiles cleanly with zero warnings.